### PR TITLE
update wp-skeleton-installer to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
         "leafo/lessphp": "*",
 
-        "wemakecustom/wp-skeleton-installer": "~2.0",
+        "wemakecustom/wp-skeleton-installer": "~3.0",
         "wemakecustom/wp-skeleton-theme": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Since the installer have been updated, change wp-skeleton-installer in composer to get the last version available, thus 3.0.
