### PR TITLE
Fix version dependencies in composer and bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,88 @@
 Wordpress Skeleton
 ==================
 
-**wp-skeleton** is a very thin wrapper around [wp-skeleton-installer](https://github.com/wemakecustom/wp-skeleton-installer).
-The easy way to install WordPress and get it works.
+Thin wrapper around [wp-skeleton-installer][1] to easly install WordPress and get it works.
+
 
 ## What it does
 
-If you use this wrapper, you will get :
-- Packages dependencies management with composer :
-  * wemakecustom/wp-skeleton-installer (needed for this wrapper to work properly) 
-  * wemakecustom/wp-skeleton-theme
-  * wemakecustom/wp-skeleton-theme-demo (child theme in dev environnement)
-  * leafo/lessphp
-  * wpackagist-plugin/w3-total-cache
-  * wpackagist-plugin/wordpress-seo
-- Libraries dependencies management with bower :
-  * jquery (version <2.0)
-  * bootstrap (version ~3.0)
-  * font-awesome
-  * console-polyfill
-  * underscore
-  * modernizr
-- a LESS compiler (LESSC.php).
-- a basic .HTACCESS (that include rewriterules for LESS files, compression, expires headers).
+Install selected plugins and a custom theme for a clean starting WordPress:
+* [wemakecustom/wp-skeleton-installer][1] (version ^3.0) is needed for this wrapper to work properly
+* [wpackagist-plugin/w3-total-cache][4] (version ^0.9)
+* [wpackagist-plugin/wordpress-seo][5] (version ^3.0)
+* [wemakecustom/wp-skeleton-theme][2]
+* [wemakecustom/wp-skeleton-theme-demo][3]
+* [leafo/lessphp][6] (version ^0.5) to compile LESS files
+* and an ``.htaccess`` that include rewriterules for LESS files, compression and expires headers.
+
+Install libraries for an easy custom integration:
+* [bootstrap][7] (version ~3.0) is a front-end framework for faster and easier web development.
+* [font-awesome][8] (version ~4.0) is an iconic font for easy scalable vector graphics.
+* [jquery][9] (version <2.0) is the most used javascript library.
+* [modernizr][10] (version ~3.0) is a javascript library that detects HTML5 and CSS3 in user browser.
+* [underscore][11] provides a lot of useful javascript helpers.
+* [console-polyfill][12] is a light library to makes it safe to do ``console.log()``.
+
+[1]: https://github.com/wemakecustom/wp-skeleton-installer
+[2]: https://github.com/wemakecustom/wp-skeleton-theme
+[3]: https://github.com/wemakecustom/wp-skeleton-theme-demo
+[4]: https://en-ca.wordpress.org/plugins/w3-total-cache
+[5]: https://en-ca.wordpress.org/plugins/wordpress-seo
+[6]: https://github.com/leafo/lessphp
+[7]: https://github.com/twbs/bootstrap
+[8]: https://github.com/FortAwesome/Font-Awesome
+[9]: https://github.com/jquery/jquery
+[10]: https://github.com/modernizr/modernizr
+[11]: https://github.com/jashkenas/underscore
+[12]: https://github.com/paulmillr/console-polyfill
+
 
 ## Installation
 
-Clone this git repo.
 ````
-$ git clone git@github.com:wemakecustom/wp-skeleton.git
-````
-Run composer to install.
-````
+$ git clone git@github.com:wemakecustom/wp-skeleton.git <project>
+$ cd <project>
 $ composer install
 ````
-Or if you doesn't need the demo theme
+If you doesn't need the ``wp-skeleton-theme-demo`` theme:
+
 ````
 $ composer install --no-dev
 ````
-Run bower to get all recent script up to date in _/wp-content/components_.
+By default, at the end, you will get WordPress and all configs files installed in ``<project>/htdocs/`` subfolder. To configure another subfolder, please see section _configuration_ bellow.
+
+After that, you have to create the WordPress tables in the database with [wp-cli][13], a command-line tools for managing WordPress.
+You can read [more information here][14] about ``wp core install`` command.
+
 ````
-$ bower update
+$ bin/wp core install --path=htdocs/ --url=<url> --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email>
+````
+Then, finish by running bower to get all recent script up to date in ``<project>/htdocs/wp-content/components/``.
+
+````
+$ bower install
 ````
 
-## Documentation
+[13]: http://wp-cli.org/
+[14]: http://wp-cli.org/commands/core/install/
+[15]: https://github.com/wemakecustom/wp-skeleton-installer#configuration
 
-- https://github.com/wemakecustom/wp-skeleton-installer
-- https://github.com/wemakecustom/wp-skeleton-theme
-- https://github.com/wemakecustom/wp-skeleton-theme-demo
-- https://github.com/leafo/lessphp
-- http://wpackagist.org/
+
+## Configuration
+
+The following section in ``composer.json`` allow you to change the folder where WordPress and the config files are installed.
+For details about this section, please see [wp-skeleton-installer][15].
+
+```json
+{
+    "extra": {
+        "wordpress-install-dir": "vendor/wordpress/wordpress",
+        "web-dir": "htdocs",
+        "installer-paths": {
+            "htdocs/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+            "htdocs/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+            "htdocs/wp-content/themes/composer/{$name}/": ["type:wordpress-theme"]
+        }
+    }
+}
+```

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "jquery": "<2.0",
     "bootstrap": "~3.0",
-    "font-awesome": "*",
+    "font-awesome": "~4.0",
     "console-polyfill": "*",
     "underscore": "*",
-    "modernizr": "*"
+    "modernizr": "~3.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "wpackagist-plugin/w3-total-cache": "*",
+        "wpackagist-plugin/w3-total-cache": "^0.9",
         "wpackagist-plugin/wordpress-seo": "*",
 
         "leafo/lessphp": "*",

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,6 @@
     "require-dev": {
         "wemakecustom/wp-skeleton-theme-demo": "*"
     },
-    "suggest": {
-        "wpackagist-plugin/types": "Custom Types",
-        "wp-plugins/cred": "Custom Types Form Builder",
-        "wp-plugins/types-access": "Custom Types Access List",
-        "wp-plugins/wp-views": "Custom Types Views",
-
-        "wp-plugins/sitepress-multilingual-cms": "Mutlilingual support",
-        "wp-plugins/wpml-string-translation": "Mutlilingual String Translation",
-        "wp-plugins/wpml-translation-analytics": "Mutlilingual Translation Analytics",
-        "wp-plugins/wpml-translation-management": "Mutlilingual Translation Management",
-
-        "wp-plugins/gravityforms": "Form builder",
-        "wp-plugins/gravityforms-multilingual": "Form builder multilingual support",
-        "wp-plugins/gravityforms-paypal": "Form builder PayPal support"
-    },
     "replace": {
         "wemakecustom/wp-skeleton": "self.version"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "wpackagist-plugin/w3-total-cache": "^0.9",
-        "wpackagist-plugin/wordpress-seo": "*",
+        "wpackagist-plugin/wordpress-seo": "^3.0",
 
         "leafo/lessphp": "*",
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
         "leafo/lessphp": "*",
 
-        "wemakecustom/wp-skeleton-installer": "~3.0",
+        "wemakecustom/wp-skeleton-installer": "^3.0",
         "wemakecustom/wp-skeleton-theme": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "wpackagist-plugin/w3-total-cache": "^0.9",
         "wpackagist-plugin/wordpress-seo": "^3.0",
 
-        "leafo/lessphp": "*",
+        "leafo/lessphp": "^0.5",
 
         "wemakecustom/wp-skeleton-installer": "^3.0",
         "wemakecustom/wp-skeleton-theme": "*"


### PR DESCRIPTION
Hi,
Since [wp-skeleton-installer](https://github.com/wemakecustom/wp-skeleton-installer) was updated, I also made some changes in dependencies version for composer packages and bower libraries. It will insure the installation will work correctly.
Also, since `wp-skeleton` is developer-oriented, I think it would be more convenient to let the developer add require plugins when they install and set a custom wordpress.
